### PR TITLE
잘못된 토큰으로 인증하는 경우 처리

### DIFF
--- a/src/main/java/com/dallab/cattoy/SecurityJavaConfig.java
+++ b/src/main/java/com/dallab/cattoy/SecurityJavaConfig.java
@@ -1,6 +1,7 @@
 package com.dallab.cattoy;
 
 import com.dallab.cattoy.authentication.JwtAuthenticationFilter;
+import com.dallab.cattoy.authentication.SignatureExceptionFilter;
 import com.dallab.cattoy.util.JwtUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -28,8 +29,11 @@ public class SecurityJavaConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         // 사용자 인증을 위한 필터.
-        Filter filter = new JwtAuthenticationFilter(
+        Filter jwtAuthenticationFilter = new JwtAuthenticationFilter(
                 authenticationManager(), jwtUtil());
+
+        // JWT 서명 오류 처리를 위한 필터.
+        Filter signatureExceptionFilter = new SignatureExceptionFilter();
 
         http
                 .cors().disable()
@@ -37,7 +41,9 @@ public class SecurityJavaConfig extends WebSecurityConfigurerAdapter {
                 .formLogin().disable()
                 .headers().frameOptions().disable()
                 .and()
-                .addFilter(filter)
+                .addFilter(jwtAuthenticationFilter)
+                .addFilterBefore(signatureExceptionFilter,
+                        JwtAuthenticationFilter.class)
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()

--- a/src/main/java/com/dallab/cattoy/advice/ControllerErrorAdvice.java
+++ b/src/main/java/com/dallab/cattoy/advice/ControllerErrorAdvice.java
@@ -1,9 +1,12 @@
 package com.dallab.cattoy.advice;
 
+import io.jsonwebtoken.security.SignatureException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -14,6 +17,13 @@ public class ControllerErrorAdvice {
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<?> handleNotFound() {
         return ResponseEntity.notFound().build();
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ResponseBody
+    @ExceptionHandler(SignatureException.class)
+    public String handleInvalidToken() {
+        return "Invalid Token";
     }
 
 }

--- a/src/main/java/com/dallab/cattoy/advice/ControllerErrorAdvice.java
+++ b/src/main/java/com/dallab/cattoy/advice/ControllerErrorAdvice.java
@@ -1,12 +1,9 @@
 package com.dallab.cattoy.advice;
 
-import io.jsonwebtoken.security.SignatureException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -17,13 +14,6 @@ public class ControllerErrorAdvice {
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<?> handleNotFound() {
         return ResponseEntity.notFound().build();
-    }
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ResponseBody
-    @ExceptionHandler(SignatureException.class)
-    public String handleInvalidToken() {
-        return "Invalid Token";
     }
 
 }

--- a/src/main/java/com/dallab/cattoy/authentication/SignatureExceptionFilter.java
+++ b/src/main/java/com/dallab/cattoy/authentication/SignatureExceptionFilter.java
@@ -1,0 +1,29 @@
+package com.dallab.cattoy.authentication;
+
+import io.jsonwebtoken.security.SignatureException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+// JWT SignatureException 에러 처리 필터.
+public class SignatureExceptionFilter extends HttpFilter {
+
+    @Override
+    public void doFilter(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain
+    ) throws IOException, ServletException {
+        try {
+            chain.doFilter(request, response);
+        } catch (SignatureException e) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Invalid Token");
+        }
+    }
+
+}

--- a/src/test/java/com/dallab/cattoy/controller/ProductControllerTest.java
+++ b/src/test/java/com/dallab/cattoy/controller/ProductControllerTest.java
@@ -38,6 +38,12 @@ public class ProductControllerTest {
             "eyJ1c2VySWQiOjEsIm5hbWUiOiLqtIDrpqzsnpAifQ." +
             "EyrTP4OAGH9fA7lYxHrmJibf9QpBZnijtet-bWiTu2k";
 
+    // 다른 key값으로 다른 시스템에서 만들어진 토
+    private static final String INVALID_TOKEN = "eyJhbGciOiJIUzI1NiJ9." +
+            "eyJjb21wYW55TmFtZSI6ImF1dG9ldmVyIiwic3lzdGVtTmFtZSI6InVzZWR" +
+            "DYXIiLCJjcmVhdGVkQXQiOiIyMDE5LTEwLTI1IiwiZXhwaXJlQXQiOiIyMDIwLTEwLTI1In0" +
+            ".-PZ-MY4EE1uJ6YJbjeVW4yXF4rRZ1U6NTPx9BdLCkhU";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -110,6 +116,20 @@ public class ProductControllerTest {
                                 "\"price\":5000}")
         )
                 .andExpect(status().isForbidden());
+    }
+
+    // io.jsonwebtoken.security.SignatureException 발생
+    // advice에 등록된 상태
+    @Test
+    public void createWithInvalidToken() throws Exception {
+        mockMvc.perform(
+                post("/products")
+                        .header("Authorization", "Bearer " + INVALID_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"낚시대\",\"maker\":\"달랩\"," +
+                                "\"price\":5000}")
+        )
+                .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/src/test/java/com/dallab/cattoy/controller/ProductControllerTest.java
+++ b/src/test/java/com/dallab/cattoy/controller/ProductControllerTest.java
@@ -38,7 +38,7 @@ public class ProductControllerTest {
             "eyJ1c2VySWQiOjEsIm5hbWUiOiLqtIDrpqzsnpAifQ." +
             "EyrTP4OAGH9fA7lYxHrmJibf9QpBZnijtet-bWiTu2k";
 
-    // 다른 key값으로 다른 시스템에서 만들어진 토
+    // 다른 key(secret)로 서명된 토큰
     private static final String INVALID_TOKEN = "eyJhbGciOiJIUzI1NiJ9." +
             "eyJjb21wYW55TmFtZSI6ImF1dG9ldmVyIiwic3lzdGVtTmFtZSI6InVzZWR" +
             "DYXIiLCJjcmVhdGVkQXQiOiIyMDE5LTEwLTI1IiwiZXhwaXJlQXQiOiIyMDIwLTEwLTI1In0" +
@@ -118,8 +118,6 @@ public class ProductControllerTest {
                 .andExpect(status().isForbidden());
     }
 
-    // io.jsonwebtoken.security.SignatureException 발생
-    // advice에 등록된 상태
     @Test
     public void createWithInvalidToken() throws Exception {
         mockMvc.perform(
@@ -129,7 +127,8 @@ public class ProductControllerTest {
                         .content("{\"name\":\"낚시대\",\"maker\":\"달랩\"," +
                                 "\"price\":5000}")
         )
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string(containsString("Invalid Token")));
     }
 
     @Test


### PR DESCRIPTION
- 임의의 시스템에서 다른 key로 만들어진 토큰으로 인증 시도를합니다(변조 시도)
- 이 경우 Unauthorized 응답을 주도록 하기 위해 advice에 에러 처리를 넣었습니다.
- 하지만 계속해서 에러가 덮어지지 않고 기존에 발생하는 500 에러가 발생합니다.
- 이런 상황을 처리하는 방법에 대해 조언주시면 감사하겠습니다